### PR TITLE
refactor: 연관관계 재설정 및 요청 응답 DTO 수정

### DIFF
--- a/src/main/kotlin/com/todo/todoapplication/domain/comment/dto/request/CommentCreateRequest.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/comment/dto/request/CommentCreateRequest.kt
@@ -1,31 +1,20 @@
 package com.todo.todoapplication.domain.comment.dto.request
 
-import com.todo.todoapplication.domain.comment.model.Account
-import com.todo.todoapplication.domain.comment.model.Comment
-import com.todo.todoapplication.domain.todo.model.Todo
+import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 
 data class CommentCreateRequest(
-    @field:NotBlank(message = "작성자는 필수 입력 사항입니다.")
-    val name: String,
+    @field:NotBlank(message = "작성자 이메일은 필수 입력 사항입니다.")
+    @field:Email(message = "올바른 이메일 형식이 아닙니다.")
+    val email: String,
 
-    @field:Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,}${'$'}", message = "비밀번호는 영문과 특수문자 숫자를 포함하며 8자 이상이어야 합니다.")
+    @field:Pattern(
+        regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,}${'$'}",
+        message = "비밀번호는 영문과 특수문자 숫자를 포함하며 8자 이상이어야 합니다."
+    )
     val password: String,
 
     @field:NotBlank(message = "댓글 내용은 필수 입력 사항입니다.")
     val content: String
-) {
-
-    fun toEntity(todo: Todo): Comment {
-        return Comment(
-            content = content,
-            account = Account(
-                name = name,
-                password = password
-            ),
-            todo = todo
-        )
-    }
-
-}
+)

--- a/src/main/kotlin/com/todo/todoapplication/domain/comment/dto/request/UpdateCommentRequest.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/comment/dto/request/UpdateCommentRequest.kt
@@ -3,7 +3,8 @@ package com.todo.todoapplication.domain.comment.dto.request
 import jakarta.validation.constraints.NotBlank
 
 data class UpdateCommentRequest(
-    val name: String,
+
+    val email: String,
     val password: String,
 
     @field:NotBlank(message = "댓글 내용은 필수 입력 사항입니다.")

--- a/src/main/kotlin/com/todo/todoapplication/domain/comment/dto/response/CommentResponse.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/comment/dto/response/CommentResponse.kt
@@ -1,17 +1,6 @@
 package com.todo.todoapplication.domain.comment.dto.response
 
-import com.todo.todoapplication.domain.comment.model.Comment
-
 data class CommentResponse(
-    val name: String,
+    val email: String,
     val content: String
-) {
-    companion object {
-        fun from(comment: Comment): CommentResponse {
-            return CommentResponse(
-                name = comment.account.name,
-                content = comment.content
-            )
-        }
-    }
-}
+)

--- a/src/main/kotlin/com/todo/todoapplication/domain/comment/model/Account.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/comment/model/Account.kt
@@ -1,9 +1,0 @@
-package com.todo.todoapplication.domain.comment.model
-
-import jakarta.persistence.Embeddable
-
-@Embeddable
-data class Account(
-    val name: String,
-    val password: String
-)

--- a/src/main/kotlin/com/todo/todoapplication/domain/comment/repository/CommentRepository.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/comment/repository/CommentRepository.kt
@@ -1,15 +1,12 @@
 package com.todo.todoapplication.domain.comment.repository
 
-import com.todo.todoapplication.domain.comment.exception.COMMENT_NOT_FOUND_MESSAGE
 import com.todo.todoapplication.domain.comment.model.Comment
-import com.todo.todoapplication.global.exception.NoSuchEntityException
+import com.todo.todoapplication.domain.todo.model.Todo
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
 @Repository
 interface CommentRepository : JpaRepository<Comment, Long> {
-    fun findAllByTodoId(todoId: Long): List<Comment>
-    fun getCommentById(commentId: Long): Comment =
-        this.findByIdOrNull(commentId) ?: throw NoSuchEntityException(COMMENT_NOT_FOUND_MESSAGE)
+    fun findAllByTodo(todo: Todo): List<Comment>
+
 }

--- a/src/main/kotlin/com/todo/todoapplication/domain/comment/service/CommentService.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/comment/service/CommentService.kt
@@ -3,8 +3,12 @@ package com.todo.todoapplication.domain.comment.service
 import com.todo.todoapplication.domain.comment.dto.request.CommentCreateRequest
 import com.todo.todoapplication.domain.comment.dto.request.UpdateCommentRequest
 import com.todo.todoapplication.domain.comment.dto.response.CommentResponse
+import com.todo.todoapplication.domain.comment.exception.COMMENT_NOT_FOUND_MESSAGE
 import com.todo.todoapplication.domain.comment.repository.CommentRepository
+import com.todo.todoapplication.domain.todo.exception.TODO_NOT_FOUND_MESSAGE
 import com.todo.todoapplication.domain.todo.repository.TodoRepository
+import com.todo.todoapplication.global.exception.NoSuchEntityException
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -17,7 +21,7 @@ class CommentService(
     // C
     @Transactional
     fun createComment(todoId: Long, request: CommentCreateRequest): Long {
-        val todo = todoRepository.getTodoById(todoId)
+        val todo = todoRepository.findByIdOrNull(todoId) ?: throw NoSuchEntityException(TODO_NOT_FOUND_MESSAGE)
         val comment = commentRepository.save(request.toEntity(todo))
 
         return comment.id!!
@@ -26,7 +30,8 @@ class CommentService(
     // R
     @Transactional(readOnly = true)
     fun findAll(todoId: Long): List<CommentResponse> {
-        val comments = commentRepository.findAllByTodoId(todoId)
+        val todo = todoRepository.findByIdOrNull(todoId) ?: throw NoSuchEntityException(TODO_NOT_FOUND_MESSAGE)
+        val comments = commentRepository.findAllByTodo(todo)
 
         return comments.map { CommentResponse.from(it) }
     }
@@ -34,7 +39,9 @@ class CommentService(
     // U
     @Transactional
     fun updateComment(commentId: Long, request: UpdateCommentRequest): CommentResponse {
-        val comment = commentRepository.getCommentById(commentId)
+        val comment = commentRepository.findByIdOrNull(commentId) ?: throw NoSuchEntityException(
+            COMMENT_NOT_FOUND_MESSAGE
+        )
 
         comment.update(request)
 
@@ -44,7 +51,7 @@ class CommentService(
     // D
     @Transactional
     fun deleteComment(commentId: Long) {
-        val comment = commentRepository.getCommentById(commentId)
+        val comment = commentRepository.findByIdOrNull(commentId) ?: throw NoSuchEntityException(COMMENT_NOT_FOUND_MESSAGE)
 
         commentRepository.delete(comment)
     }

--- a/src/main/kotlin/com/todo/todoapplication/domain/todo/controller/TodoController.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/todo/controller/TodoController.kt
@@ -1,6 +1,7 @@
 package com.todo.todoapplication.domain.todo.controller
 
 import com.todo.todoapplication.domain.todo.dto.request.TodoCreateRequest
+import com.todo.todoapplication.domain.todo.dto.request.TodoFilterByNameRequest
 import com.todo.todoapplication.domain.todo.dto.request.TodoSortRequest
 import com.todo.todoapplication.domain.todo.dto.request.TodoUpdateRequest
 import com.todo.todoapplication.domain.todo.dto.response.TodoResponse
@@ -28,15 +29,12 @@ class TodoController(private val todoService: TodoService) {
         return ResponseEntity.ok(response)
     }
 
-    @GetMapping("/{name}")
-    fun getTodoByName(@PathVariable name: String): ResponseEntity<List<TodoResponse>> {
-        val response = todoService.getTodoByName(name)
-        return ResponseEntity.ok(response)
-    }
-
     @GetMapping
-    fun getTodoList(todoSortRequest: TodoSortRequest): ResponseEntity<List<TodoResponse>> {
-        val response = todoService.getTodoList(todoSortRequest)
+    fun getTodoList(
+        todoSortRequest: TodoSortRequest,
+        todoFilterByNameRequest: TodoFilterByNameRequest
+    ): ResponseEntity<List<TodoResponse>> {
+        val response = todoService.getTodoList(todoSortRequest, todoFilterByNameRequest)
         return ResponseEntity.ok(response)
     }
 

--- a/src/main/kotlin/com/todo/todoapplication/domain/todo/dto/request/TodoCreateRequest.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/todo/dto/request/TodoCreateRequest.kt
@@ -1,6 +1,6 @@
 package com.todo.todoapplication.domain.todo.dto.request
 
-import com.todo.todoapplication.domain.todo.model.Todo
+import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
@@ -12,15 +12,9 @@ data class TodoCreateRequest(
     val description: String,
 
     @field:NotBlank(message = "작성자는 필수 입력 사항입니다.")
-    val name: String
-) {
+    val name: String,
 
-    fun toEntity(): Todo {
-        return Todo(
-            title = title,
-            description = description,
-            name = name
-        )
-    }
-
-}
+    @field:NotBlank(message = "작성자 이메일은 필수 입력 사항입니다.")
+    @field:Email(message = "올바른 이메일 형식이 아닙니다.")
+    val email: String
+)

--- a/src/main/kotlin/com/todo/todoapplication/domain/todo/dto/request/TodoFilterByNameRequest.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/todo/dto/request/TodoFilterByNameRequest.kt
@@ -1,0 +1,5 @@
+package com.todo.todoapplication.domain.todo.dto.request
+
+data class TodoFilterByNameRequest(
+    val name: String = ""
+)

--- a/src/main/kotlin/com/todo/todoapplication/domain/todo/dto/request/TodoUpdateRequest.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/todo/dto/request/TodoUpdateRequest.kt
@@ -11,5 +11,5 @@ data class TodoUpdateRequest(
     val description: String,
 
     @field:NotBlank(message = "작성자는 필수 입력 사항입니다.")
-    val name: String
+    val name: String,
 )

--- a/src/main/kotlin/com/todo/todoapplication/domain/todo/dto/response/TodoResponse.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/todo/dto/response/TodoResponse.kt
@@ -1,18 +1,20 @@
 package com.todo.todoapplication.domain.todo.dto.response
 
-import com.todo.todoapplication.domain.comment.model.Comment
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.todo.todoapplication.domain.comment.dto.response.CommentResponse
 import com.todo.todoapplication.domain.todo.model.Todo
 import java.time.LocalDateTime
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class TodoResponse(
     val id: Long,
     val title: String,
     val description: String,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
-    val author: String,
+    val name: String,
     val completed: Boolean,
-    var comments: List<Comment>? = null
+    var comments: List<CommentResponse>? = null
 ) {
     companion object {
         fun from(todo: Todo): TodoResponse {
@@ -27,7 +29,7 @@ data class TodoResponse(
             )
         }
 
-        fun from(todo: Todo, comments: List<Comment>): TodoResponse {
+        fun from(todo: Todo, comments: List<CommentResponse>): TodoResponse {
             return TodoResponse(
                 todo.id!!,
                 todo.title,

--- a/src/main/kotlin/com/todo/todoapplication/domain/todo/dto/response/TodoResponse.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/todo/dto/response/TodoResponse.kt
@@ -2,7 +2,6 @@ package com.todo.todoapplication.domain.todo.dto.response
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.todo.todoapplication.domain.comment.dto.response.CommentResponse
-import com.todo.todoapplication.domain.todo.model.Todo
 import java.time.LocalDateTime
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -15,32 +14,4 @@ data class TodoResponse(
     val name: String,
     val completed: Boolean,
     var comments: List<CommentResponse>? = null
-) {
-    companion object {
-        fun from(todo: Todo): TodoResponse {
-            return TodoResponse(
-                todo.id!!,
-                todo.title,
-                todo.description,
-                todo.createdAt,
-                todo.updatedAt,
-                todo.name,
-                todo.completed
-            )
-        }
-
-        fun from(todo: Todo, comments: List<CommentResponse>): TodoResponse {
-            return TodoResponse(
-                todo.id!!,
-                todo.title,
-                todo.description,
-                todo.createdAt,
-                todo.updatedAt,
-                todo.name,
-                todo.completed,
-                comments = comments
-            )
-        }
-    }
-
-}
+)

--- a/src/main/kotlin/com/todo/todoapplication/domain/todo/model/Todo.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/todo/model/Todo.kt
@@ -1,34 +1,42 @@
 package com.todo.todoapplication.domain.todo.model
 
+import com.todo.todoapplication.domain.comment.dto.response.CommentResponse
+import com.todo.todoapplication.domain.todo.dto.request.TodoCreateRequest
+import com.todo.todoapplication.domain.todo.dto.response.TodoResponse
+import com.todo.todoapplication.domain.user.model.User
 import com.todo.todoapplication.global.entity.BaseEntity
 import jakarta.persistence.*
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 
 @Entity
 @Table(name = "todos")
-class Todo(
-    title: String, description: String, name: String
-) : BaseEntity() {
-
+class Todo private constructor(
     @Column(name = "title")
-    var title = title
-        private set
+    private var title: String,
 
     @Column(name = "description")
-    var description = description
-        private set
+    private var description: String,
 
     @Column(name = "name")
-    var name = name
-        private set
+    private var name: String,
 
-    @Column(name = "complete")
-    var completed = false
-        private set
+    user: User
+) : BaseEntity() {
 
     @Id
     @Column(name = "todo_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "user_id")
+    var user = user
+        private set
+
+    @Column(name = "complete")
+    private var completed: Boolean = false
 
     fun update(title: String, description: String, author: String) {
         this.title = title
@@ -40,4 +48,41 @@ class Todo(
         this.completed = !completed
     }
 
+    fun from(): TodoResponse {
+        return TodoResponse(
+            this.id!!,
+            this.title,
+            this.description,
+            this.createdAt,
+            this.updatedAt,
+            this.name,
+            this.completed
+        )
+    }
+
+    fun from(comments: List<CommentResponse>): TodoResponse {
+        return TodoResponse(
+            this.id!!,
+            this.title,
+            this.description,
+            this.createdAt,
+            this.updatedAt,
+            this.name,
+            this.completed,
+            comments = comments
+        )
+    }
+
+    companion object {
+
+        fun toEntity(request: TodoCreateRequest, user: User): Todo {
+            return Todo(
+                title = request.title,
+                description = request.description,
+                name = request.name,
+                user = user
+            )
+
+        }
+    }
 }

--- a/src/main/kotlin/com/todo/todoapplication/domain/todo/repository/TodoRepository.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/todo/repository/TodoRepository.kt
@@ -1,18 +1,13 @@
 package com.todo.todoapplication.domain.todo.repository
 
-import com.todo.todoapplication.domain.todo.exception.TODO_NOT_FOUND_MESSAGE
 import com.todo.todoapplication.domain.todo.model.Todo
-import com.todo.todoapplication.global.exception.NoSuchEntityException
+import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
 @Repository
 interface TodoRepository : JpaRepository<Todo, Long> {
 
-    fun getTodoById(id: Long): Todo =
-        this.findByIdOrNull(id) ?: throw NoSuchEntityException(TODO_NOT_FOUND_MESSAGE)
-
-    fun findAllByName(name: String): List<Todo>
+    fun findAllByName(name: String, sort: Sort): List<Todo>
 
 }

--- a/src/main/kotlin/com/todo/todoapplication/domain/todo/service/TodoService.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/todo/service/TodoService.kt
@@ -1,11 +1,16 @@
 package com.todo.todoapplication.domain.todo.service
 
+import com.todo.todoapplication.domain.comment.dto.response.CommentResponse
 import com.todo.todoapplication.domain.comment.repository.CommentRepository
 import com.todo.todoapplication.domain.todo.dto.request.TodoCreateRequest
+import com.todo.todoapplication.domain.todo.dto.request.TodoFilterByNameRequest
 import com.todo.todoapplication.domain.todo.dto.request.TodoSortRequest
 import com.todo.todoapplication.domain.todo.dto.request.TodoUpdateRequest
 import com.todo.todoapplication.domain.todo.dto.response.TodoResponse
+import com.todo.todoapplication.domain.todo.exception.TODO_NOT_FOUND_MESSAGE
 import com.todo.todoapplication.domain.todo.repository.TodoRepository
+import com.todo.todoapplication.global.exception.NoSuchEntityException
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -25,28 +30,33 @@ class TodoService(
     // R
     @Transactional(readOnly = true)
     fun getTodo(todoId: Long): TodoResponse {
-        val todo = todoRepository.getTodoById(todoId)
+        val todo = todoRepository.findByIdOrNull(todoId) ?: throw NoSuchEntityException(TODO_NOT_FOUND_MESSAGE)
         val comments = commentRepository.findAllByTodo(todo)
+            .map { CommentResponse.from(it) }
         return TodoResponse.from(todo, comments)
     }
 
     @Transactional(readOnly = true)
-    fun getTodoList(request: TodoSortRequest): List<TodoResponse> {
-        return todoRepository.findAll(request.toSort())
-            .map { TodoResponse.from(it) }
-    }
+    fun getTodoList(
+        todoSortRequest: TodoSortRequest,
+        todoFilterByNameRequest: TodoFilterByNameRequest
+    ): List<TodoResponse> {
+        val name = todoFilterByNameRequest.name
+        val sort = todoSortRequest.toSort()
 
-    @Transactional(readOnly = true)
-    fun getTodoByName(name: String): List<TodoResponse> {
-        return todoRepository.findAllByName(name).map {
-            TodoResponse.from(it)
+        return if (name.isNotBlank()) {
+            todoRepository.findAllByName(name, sort)
+                .map { TodoResponse.from(it) }
+        } else {
+            todoRepository.findAll(sort)
+                .map { TodoResponse.from(it) }
         }
     }
 
     // U
     @Transactional
     fun updateTodo(todoId: Long, request: TodoUpdateRequest) {
-        val todo = todoRepository.getTodoById(todoId)
+        val todo = todoRepository.findByIdOrNull(todoId) ?: throw NoSuchEntityException(TODO_NOT_FOUND_MESSAGE)
         todo.update(
             request.title,
             request.description,
@@ -56,14 +66,14 @@ class TodoService(
 
     @Transactional
     fun completeTodo(todoId: Long) {
-        val todo = todoRepository.getTodoById(todoId)
+        val todo = todoRepository.findByIdOrNull(todoId) ?: throw NoSuchEntityException(TODO_NOT_FOUND_MESSAGE)
         todo.toggleComplete()
     }
 
     // D
     @Transactional
     fun deleteTodo(todoId: Long) {
-        val todo = todoRepository.getTodoById(todoId)
+        val todo = todoRepository.findByIdOrNull(todoId) ?: throw NoSuchEntityException(TODO_NOT_FOUND_MESSAGE)
         todoRepository.delete(todo)
     }
 

--- a/src/main/kotlin/com/todo/todoapplication/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/user/controller/UserController.kt
@@ -1,0 +1,33 @@
+package com.todo.todoapplication.domain.user.controller
+
+import com.todo.todoapplication.domain.user.dto.request.LoginRequest
+import com.todo.todoapplication.domain.user.dto.request.SignupRequest
+import com.todo.todoapplication.domain.user.dto.response.LoginResponse
+import com.todo.todoapplication.domain.user.service.UserService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
+
+@RestController
+@RequestMapping("api/v1/users/")
+class UserController(
+    private val userService: UserService
+) {
+
+    @PostMapping("/signup")
+    fun signup(@RequestBody request: SignupRequest): ResponseEntity<Unit> {
+        val userId = userService.signup(request)
+        return ResponseEntity.created(URI.create(String.format("/api/v1/%d", userId))).build()
+    }
+
+    @PostMapping("/signin")
+    fun login(@RequestBody request: LoginRequest): ResponseEntity<LoginResponse> {
+        val tokenInfo = userService.login(request)
+
+        return ResponseEntity.ok(tokenInfo)
+    }
+
+}

--- a/src/main/kotlin/com/todo/todoapplication/domain/user/dto/request/LoginRequest.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/user/dto/request/LoginRequest.kt
@@ -1,0 +1,11 @@
+package com.todo.todoapplication.domain.user.dto.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class LoginRequest(
+    @field:NotBlank
+    val email: String,
+
+    @field:NotBlank
+    val password: String
+)

--- a/src/main/kotlin/com/todo/todoapplication/domain/user/dto/request/SignupRequest.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/user/dto/request/SignupRequest.kt
@@ -1,0 +1,21 @@
+package com.todo.todoapplication.domain.user.dto.request
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+
+data class SignupRequest(
+    @field:Email(message = "올바른 이메일 형식이 아닙니다")
+    @field:NotBlank
+    val email: String,
+
+    @field:NotBlank
+    @field:Pattern(
+        regexp="^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#\$%^&*])[a-zA-Z0-9!@#\$%^&*]{8,20}\$",
+        message = "비밀번호는 8~20 소/대/특수문자를 혼합하여 작성해주세요"
+    )
+    val password: String,
+
+    @field:NotBlank
+    val role: String
+)

--- a/src/main/kotlin/com/todo/todoapplication/domain/user/dto/response/LoginResponse.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/user/dto/response/LoginResponse.kt
@@ -1,0 +1,6 @@
+package com.todo.todoapplication.domain.user.dto.response
+
+data class LoginResponse(
+    val grantType: String,
+    val accessToken: String
+)

--- a/src/main/kotlin/com/todo/todoapplication/domain/user/exception/UserErrorMessage.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/user/exception/UserErrorMessage.kt
@@ -1,0 +1,3 @@
+package com.todo.todoapplication.domain.user.exception
+
+const val USER_NOT_FOUND_MESSAGE = "해당 유저가 존재하지 않습니다."

--- a/src/main/kotlin/com/todo/todoapplication/domain/user/model/User.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/user/model/User.kt
@@ -1,0 +1,35 @@
+package com.todo.todoapplication.domain.user.model
+
+import com.todo.todoapplication.domain.user.dto.request.SignupRequest
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "users")
+class User private constructor(
+    @Column(name = "email", unique = true)
+    var email: String,
+
+    @Column(name = "password")
+    val password: String,
+
+    @Column(name = "role")
+    @Enumerated(EnumType.STRING)
+    val role: UserRole
+) {
+
+    @Id
+    @Column(name = "user_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null
+        private set
+
+    companion object {
+        fun toEntity(request: SignupRequest): User {
+            return User(
+                password = request.password,
+                email = request.email,
+                role = UserRole.valueOf(request.role)
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/todo/todoapplication/domain/user/model/UserRole.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/user/model/UserRole.kt
@@ -1,0 +1,5 @@
+package com.todo.todoapplication.domain.user.model
+
+enum class UserRole {
+    ADMIN, USER
+}

--- a/src/main/kotlin/com/todo/todoapplication/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/user/repository/UserRepository.kt
@@ -1,0 +1,12 @@
+package com.todo.todoapplication.domain.user.repository
+
+import com.todo.todoapplication.domain.user.model.User
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface UserRepository : JpaRepository<User, Long> {
+    fun existsByEmail(email: String): Boolean
+    fun findByEmail(email: String): User?
+
+}

--- a/src/main/kotlin/com/todo/todoapplication/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/todo/todoapplication/domain/user/service/UserService.kt
@@ -1,0 +1,36 @@
+package com.todo.todoapplication.domain.user.service
+
+import com.todo.todoapplication.domain.user.dto.request.LoginRequest
+import com.todo.todoapplication.domain.user.dto.request.SignupRequest
+import com.todo.todoapplication.domain.user.dto.response.LoginResponse
+import com.todo.todoapplication.domain.user.exception.USER_NOT_FOUND_MESSAGE
+import com.todo.todoapplication.domain.user.model.User
+import com.todo.todoapplication.domain.user.repository.UserRepository
+import com.todo.todoapplication.global.auth.jwt.JwtTokenProvider
+import com.todo.todoapplication.global.exception.DuplicatedEmailException
+import com.todo.todoapplication.global.exception.NoSuchEntityException
+import org.springframework.stereotype.Service
+
+@Service
+class UserService(
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val userRepository: UserRepository
+) {
+    fun signup(request: SignupRequest): Long {
+        if (userRepository.existsByEmail(request.email)) {
+            throw DuplicatedEmailException("해당 이메일로 가입된 사용자가 있습니다.")
+        }
+
+        val user = User.toEntity(request)
+        userRepository.save(user)
+
+        return user.id!!
+    }
+
+    fun login(request: LoginRequest): LoginResponse {
+        val user = userRepository.findByEmail(request.email) ?: throw NoSuchEntityException(USER_NOT_FOUND_MESSAGE)
+
+        return jwtTokenProvider.generateAccessToken(user)
+    }
+
+}

--- a/src/test/kotlin/com/todo/todoapplication/domain/todo/dto/TodoCreateRequestTest.kt
+++ b/src/test/kotlin/com/todo/todoapplication/domain/todo/dto/TodoCreateRequestTest.kt
@@ -1,34 +1,21 @@
 package com.todo.todoapplication.domain.todo.dto
 
-import com.todo.todoapplication.domain.todo.dto.request.TodoCreateRequest
+import com.todo.todoapplication.fixture.TodoFixture.Companion.createTodoRequest
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.BehaviorSpec
 import org.springframework.web.bind.MethodArgumentNotValidException
 
-class TodoCreateRequestTest : BehaviorSpec(
-    {
-        given("TodoCreationRequest가 생성되었을 때") {
-            `when`("제목이 입력되지 않으면") {
-                then("InvalidTodoRequestException이 발생한다") {
-                    shouldThrowExactly<MethodArgumentNotValidException> {
-                        TodoCreateRequest(
-                            title = "",
-                            description = "내용",
-                            name = "홍길동"
-                        )
-                    }
-                }
-            }
-            `when`("작성자가 입력되지 않으면") {
-                then("InvalidTodoRequestException이 발생한다") {
-                    shouldThrowExactly<MethodArgumentNotValidException> {
-                        TodoCreateRequest(
-                            title = "제목",
-                            description = "내용",
-                            name = ""
-                        )
-                    }
-                }
+class TodoCreateRequestTest : BehaviorSpec({
+    Given("TodoCreationRequest가 생성되었을 때") {
+        When("제목이 입력되지 않으면") {
+            Then("InvalidTodoRequestException이 발생한다") {
+                shouldThrowExactly<MethodArgumentNotValidException> { createTodoRequest }
             }
         }
-    })
+        When("작성자가 입력되지 않으면") {
+            Then("InvalidTodoRequestException이 발생한다") {
+                shouldThrowExactly<MethodArgumentNotValidException> { createTodoRequest }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/todo/todoapplication/fixture/CommentFixture.kt
+++ b/src/test/kotlin/com/todo/todoapplication/fixture/CommentFixture.kt
@@ -6,11 +6,11 @@ import com.todo.todoapplication.domain.comment.dto.response.CommentResponse
 
 class CommentFixture {
     companion object {
-        val commentId = 1L
-        val wrongCommentId = 9999L
+        const val commentId = 1L
+        const val wrongCommentId = 9999L
 
         val createCommentRequest = CommentCreateRequest(
-            name = "홍길동",
+            email = "홍길동",
             password = "ghdrlfehd1!",
             content = "댓글 내용"
         )
@@ -22,24 +22,24 @@ class CommentFixture {
         )
 
         val updateCommentRequest = UpdateCommentRequest(
-            name = "홍길동",
+            email = "홍길동",
             password = "ghdrlfehd1!",
             content = "댓글 내용 수정함"
         )
 
         val updateCommentRequestWithWrongIdAndPw = UpdateCommentRequest(
-            name = "홍길동 아님",
+            email = "홍길동 아님",
             password = "ghdrlfehddksla1!",
             content = "댓글 내용 수정함"
         )
 
         val commentResponse = CommentResponse(
-            name = "홍길동",
+            email = "홍길동",
             content = "댓글 내용"
         )
 
         val updatedCommentResponse = CommentResponse(
-            name = "홍길동",
+            email = "홍길동",
             content = "댓글 내용 수정함"
         )
 

--- a/src/test/kotlin/com/todo/todoapplication/fixture/TodoFixture.kt
+++ b/src/test/kotlin/com/todo/todoapplication/fixture/TodoFixture.kt
@@ -1,6 +1,7 @@
 package com.todo.todoapplication.fixture
 
 import com.todo.todoapplication.domain.todo.dto.request.TodoCreateRequest
+import com.todo.todoapplication.domain.todo.dto.request.TodoFilterByNameRequest
 import com.todo.todoapplication.domain.todo.dto.request.TodoSortRequest
 import com.todo.todoapplication.domain.todo.dto.request.TodoUpdateRequest
 import com.todo.todoapplication.domain.todo.dto.response.TodoResponse
@@ -8,13 +9,14 @@ import java.time.LocalDateTime
 
 class TodoFixture {
     companion object {
-        val todoId = 1L
-        val wrongTodoId = 9999L
+        const val todoId = 1L
+        const val wrongTodoId = 9999L
 
         val createTodoRequest = TodoCreateRequest(
             title = "투두 제목",
             description = "투두 내용",
             name = "홍길동",
+            email = "test@naver.com"
         )
 
         val updateTodoRequest = TodoUpdateRequest(
@@ -40,6 +42,8 @@ class TodoFixture {
         )
 
         val defaultTodoSorting = TodoSortRequest()
+
+        val defaultTodoFilterByName = TodoFilterByNameRequest("")
     }
 }
 

--- a/src/test/kotlin/com/todo/todoapplication/fixture/TodoFixture.kt
+++ b/src/test/kotlin/com/todo/todoapplication/fixture/TodoFixture.kt
@@ -29,7 +29,7 @@ class TodoFixture {
             description = "투두 내용",
             createdAt = LocalDateTime.now(),
             updatedAt = LocalDateTime.now(),
-            author = "홍길동",
+            name = "홍길동",
             completed = false
         )
 


### PR DESCRIPTION
## 연관 이슈
- closes #38 
## 작업 내용
- 투두(다):유저(일) 단방향 매핑 설정
- 투두(다):유저(일) 단방향 매핑 설정
- 요청 응답 DTO 팩토리 메서드를 엔티티 클래스로 이동
- 테스트 코드 Todo, Comment Fixture 수정